### PR TITLE
Patch Pawn_InteractionsTracker.InteractedTooRecentlyToInteract

### DIFF
--- a/Source/Time Control/Core Patches/JobTracker Patches/Patch_DriverTick_Prefix.cs
+++ b/Source/Time Control/Core Patches/JobTracker Patches/Patch_DriverTick_Prefix.cs
@@ -9,9 +9,6 @@ internal class Patch_DriverTick_Prefix
 {
     public static bool Prefix(JobDriver __instance)
     {
-        return !(TimeControlBase.partialTick < 1.0) ||
-               (!TimeControlSettings.scalePawns || !TimeControlSettings.slowWork ||
-                TimeControlBase.ExcludedListOfJobDrivers.Contains(__instance.GetType().Name)) &&
-               __instance is not (JobDriver_ChatWithPrisoner or JobDriver_Tame);
+        return TimeControlBase.partialTick >= 1.0 || !TimeControlSettings.scalePawns || !TimeControlSettings.slowWork || TimeControlBase.ExcludedListOfJobDrivers.Contains(__instance.GetType());
     }
 }

--- a/Source/Time Control/Core Patches/Patch_InteractedTooRecentlyToInteract_Transpiler.cs
+++ b/Source/Time Control/Core Patches/Patch_InteractedTooRecentlyToInteract_Transpiler.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace DTimeControl.Core_Patches
+{
+	[HarmonyPatch(typeof(Pawn_InteractionsTracker), "InteractedTooRecentlyToInteract")]
+	internal class Patch_InteractedTooRecentlyToInteract_Transpiler
+	{
+		public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+		{
+			List<CodeInstruction> list = new(instructions);
+
+			// Naive find for the "canary" bytecode
+			for (int i = 0; i < list.Count; i++)
+			{
+				if (list[i].Is(OpCodes.Ldc_I4_S, 120))
+				{
+					list.Insert(i + 1, CodeInstruction.LoadField(typeof(TimeControlSettings), "speedMultiplier"));
+					list.Insert(i + 2, new(OpCodes.Conv_I4));
+					list.Insert(i + 3, new(OpCodes.Div));
+					return list;
+				}
+			}
+			Log.Warning("Time Control: Did not find bytecode to transpile for InteractedTooRecentlyToInteract");
+			return list;
+		}
+	}
+}

--- a/Source/Time Control/TimeControlBase.cs
+++ b/Source/Time Control/TimeControlBase.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using RimWorld;
 using UnityEngine;
 using Verse;
+using HarmonyLib;
+using Verse.AI;
 
 namespace DTimeControl;
 
@@ -13,16 +15,21 @@ public static class TimeControlBase
 
     public static int cycleLength = 1;
 
-    public static readonly List<string> ExcludedListOfJobDrivers;
+    public static readonly HashSet<Type> ExcludedListOfJobDrivers;
 
     static TimeControlBase()
     {
-        ExcludedListOfJobDrivers =
-        [
-            "JobDriver_TendPatient",
+        HashSet<Type> excludeList = [
+            typeof(JobDriver_TendPatient),
+            typeof(JobDriver_Slaughter),
+            typeof(JobDriver_Lovin),
+            typeof(JobDriver_ChatWithPrisoner),
+            typeof(JobDriver_Tame)
+        ];
+
+        // List of optional types that may or may not exist. Need to dynamically add these to this list.
+        List<string> conditionalExclusions = [
             "JobDriver_Stabilize",
-            "JobDriver_Slaughter",
-            "JobDriver_Lovin",
             "TMJobDriver_CastAbilityVerb", // A RimWorld of Magic
             "TMJobDriver_CastAbilitySelf", // A RimWorld of Magic
             "JobDriver_GotoAndCast", // A RimWorld of Magic
@@ -36,6 +43,18 @@ public static class TimeControlBase
             "JobDriver_ReloadTurret", // Combat Extended
             "JobDriver_Reload" // Combat Extended
         ];
+
+        for(int i = 0; i < conditionalExclusions.Count; i++)
+        {
+            var exclusion = conditionalExclusions[i];
+            var tp = AccessTools.TypeByName(exclusion);
+            if(tp is not null)
+            {
+                excludeList.Add(tp);
+            }
+        }
+        
+        ExcludedListOfJobDrivers = excludeList;
     }
 
     public static void SetCycleLength()


### PR DESCRIPTION
This PR includes a new transpiler patch to fix #2 and an optimization with the mod itself.

#### Problem:
- Performing "reduce will" or "enslave" on prisoners will not cause their will to be reduced while the time scale has been increased to >100%.
  - This is because the game checks if the previous interaction with the prisoner has occurred 120 ticks ago, based on the global tick counter. Increasing the speed multiplier causes less ticks to be counted between prisoner interactions, causing this error.

#### Solution:
- This PR patches `Pawn_InteractionsTracker.InteractedTooRecentlyToInteract`, the function that checks if a pawn has been interacted too recently, to dynamically scale the 120 limit based on the speed multiplier.
  - The patch is a transpilation to add bytecode to integer divide 120 by `TimeControlSettings.speedMultiplier`.

#### Potential side effects:
- This patch is expected to fix more bugs than known. Any place that calls the patched function will now behave like vanilla at different time scales.
- This may cause issues with low (faster) speed multipliers.

#### Miscellaneous changes:
- Changed `List<string>` for `TimeControlBase.ExcludedListOfJobDrivers` to `HashSet<Type>`.
  - This list is called with the `Contains` method for every new job driver.
    - `HashSet` is far more efficient for doing `Contains` operations.
    - Using `Type` directly reduces indirection (theoretically more efficient).
      - This comes with a cost of having a slower startup time because it is dynamically generated.


Fixes #2